### PR TITLE
일부 frontier에 대해 clear_buyer 수행 안되는 문제 해결

### DIFF
--- a/contracts/led.system/src/producer.cpp
+++ b/contracts/led.system/src/producer.cpp
@@ -221,6 +221,7 @@ namespace eosiosystem {
    }
 
    void system_contract::update_elected_producers( const block_timestamp& block_time ) {
+      bool isclear = false;
       _gstate.last_producer_schedule_update = block_time;
 
       if ((block_time.slot - _gstate2.last_frontier_service_table_update.slot) > blocks_per_day){
@@ -234,13 +235,16 @@ namespace eosiosystem {
                   info.decrease_service_weight = 0;
                }
                if ((block_time.slot - _gstate2.last_frontier_buyer_table_clear_time.slot) > blocks_per_week * 4){
-                  _gstate2.last_frontier_buyer_table_clear_time = block_time;
+                  isclear = true;
                   info.clear_buyers();
                }
             });
          }
+         if(isclear){
+            _gstate2.last_frontier_buyer_table_clear_time = block_time;
+         }
       }
-
+      
       if (((block_time.slot - _gstate.last_producer_size_update.slot) > (blocks_per_year / 2)) && _gstate.maximum_producers != 21){
          _gstate.last_producer_size_update = block_time;
          _gstate.maximum_producers += 6;


### PR DESCRIPTION
## Related Issue

resolve: #5 

## Description

* ``` _gstate2.last_frontier_buyer_table_clear_time = block_time;``` 구문을 For문 밖으로 이동
* 위 구문은 last_frontier_buyer_table_clear_time으로 부터 4주가 지나면 trigger 되는 flag를 설정함으로써 해당 flag가 true일 때 실행되도록 수정

